### PR TITLE
Add purgecss ignore rule

### DIFF
--- a/src/Notifications.svelte
+++ b/src/Notifications.svelte
@@ -14,6 +14,7 @@
 </ul>
 
 <style>
+	/* purgecss start ignore */
 	:global(.toasts) {
 		list-style: none;
 		position: fixed;
@@ -89,7 +90,7 @@
 			width: 0; 
 		}
 	}
-	
+	/* purgecss end ignore */
 </style>
 
 <script>


### PR DESCRIPTION
[Notifications.svelte](https://github.com/beyonk-adventures/svelte-notifications/blob/master/src/Notifications.svelte)'s style will be purge when using [svelte-preprocess-postcss](https://www.npmjs.com/package/svelte-preprocess-postcss) and [purgecss](https://github.com/FullHuman/postcss-purgecss) to process the style.

I've created a [repo](https://github.com/biaocy/svelte-tailwindcss-demo) that can reproduce the problem.
The selector in `Notifications.svelte` get purged when you execute `npm run dev`.

The repo's [branch](https://github.com/biaocy/svelte-tailwindcss-demo/tree/fixed) has a workaround, which explicitly filter the class name in `Notifications.svelte` by configure `purgecss`'s `whitelist` option.

To fix this problem correctly, we can add purgecss ignore rule in `Notifications.svelte`.