### PR TITLE
chore: timeout parameter for notifications shouldn't be required

### DIFF
--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -1,27 +1,31 @@
-declare module "@beyonk/svelte-notifications" {
-    import { SvelteComponentTyped } from 'svelte/types/runtime'
+declare module '@beyonk/svelte-notifications' {
+  import { SvelteComponentTyped } from 'svelte/types/runtime'
 
-    export type TNotificationTypes =
-        'default' | 'danger' | 'warning' | 'info' | 'success'
+  export type TNotificationTypes =
+    | 'default'
+    | 'danger'
+    | 'warning'
+    | 'info'
+    | 'success'
 
-    export interface TNotifier {
-        send(message: string, type: TNotificationTypes, timeout: number): void
-        danger(message: string, timeout: number): void
-        warning(message: string, timeout: number): void
-        info(message: string, timeout: number): void
-        success(message: string, timeout: number): void
-    }
+  export interface TNotifier {
+    send(message: string, type: TNotificationTypes, timeout?: number): void
+    danger(message: string, timeout?: number): void
+    warning(message: string, timeout?: number): void
+    info(message: string, timeout?: number): void
+    success(message: string, timeout?: number): void
+  }
 
-    export interface ITheme {
-        danger: '#bb2124',
-        success: '#22bb33',
-        warning: '#f0ad4e',
-        info: '#5bc0de',
-        default: '#aaaaaa'
-    }
-    type IProps = { themes?: ITheme, timeout?: number, persist?: boolean }
+  export interface ITheme {
+    danger: '#bb2124'
+    success: '#22bb33'
+    warning: '#f0ad4e'
+    info: '#5bc0de'
+    default: '#aaaaaa'
+  }
+  type IProps = { themes?: ITheme; timeout?: number; persist?: boolean }
 
-    export class NotificationDisplay extends SvelteComponentTyped<IProps>{}
+  export class NotificationDisplay extends SvelteComponentTyped<IProps> {}
 
-    export const notifier: TNotifier;
+  export const notifier: TNotifier
 }


### PR DESCRIPTION
- update timeout paramter in interface TNotifier to be optional

Closes https://github.com/beyonk-adventures/svelte-notifications/issues/29

Note that the project could benefit from https://editorconfig.org/ or prettier config to set code style. I had to change my local prettier settings to conform to the project style. The changed `index.d.ts` file didn't conform to the project style, so there are a couple of formatting changes too.