### PR TITLE
Add support for icons in notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ You can call multiple types of notification:
 ```js
 const options = {
   timeout: 3000, // milliseconds
-  persist: false // automatic timeout (ignores above)
+  persist: false, // automatic timeout (ignores above)
+  showProgess: true, // Show (or Hide) the progress bar
+  icon: null // Add svelte component to render an icon
 }
 
 notifier.show('danger', message, options)
@@ -153,6 +155,25 @@ function someFunction () {
 </script>
 ```
 
+##### Show Progress:
+
+You can show or hide the progress bar per message
+
+```svelte
+<NotificationDisplay />
+
+<button on:click={someFunction}>Show message</button>
+
+<script>
+import { NotificationDisplay, notifier } from '@beyonk/svelte-notifications'
+
+function someFunction () {
+  notifier.success('Notifications work!', { showProgress: false }) // built in theme
+  notifier.send('custom-theme', 'Notifications work!', { showProgress: true }) // custom theme
+}
+</script>
+```
+
 ##### Persist
 
 You can make a message persist and never timeout, having a close button that the user can click to remove it.
@@ -170,6 +191,34 @@ function someFunction () {
   notifier.send('custom-theme', 'Notifications work!', { perist: true }) // custom theme
 }
 </script>
+```
+
+##### Icons
+
+You can include custom svelte components to render icons (or anything).
+
+```svelte
+<NotificationDisplay />
+
+<button on:click={someFunction}>Show message</button>
+
+<script>
+import { NotificationDisplay, notifier } from '@beyonk/svelte-notifications'
+impoer Icon from 'somewhere/Icon.svelte'
+
+function someFunction () {
+  notifier.success('Notifications work!', { icon: Icon })
+}
+</script>
+
+// Icon.svelte
+
+<svg width="1em" height="1em" viewBox="0 0 36 36">
+  <path
+    fill="currentColor"
+    d="M18 34a16 16 0 1 1 16-16a16 16 0 0 1-16 16Zm0-30a14 14 0 1 0 14 14A14 14 0 0 0 18 4Z"
+  </path>
+</svg>
 ```
 
 ## Credits

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@beyonk/eslint-config': ^5.0.2
@@ -13,9 +13,9 @@ devDependencies:
   '@beyonk/eslint-config': 5.0.2_eslint@7.32.0
   '@sveltejs/kit': 1.0.0-next.322_svelte@3.47.0
   eslint: 7.32.0
-  eslint-plugin-svelte3: 3.4.1_eslint@7.32.0+svelte@3.47.0
+  eslint-plugin-svelte3: 3.4.1_4oxeyilw5mxcaksmcxtpjddhfe
   svelte: 3.47.0
-  svelte2tsx: 0.5.9_svelte@3.47.0+typescript@4.6.3
+  svelte2tsx: 0.5.9_ucc3fdkrl6lb7lhnlfimbouujy
   typescript: 4.6.3
 
 packages:
@@ -46,11 +46,16 @@ packages:
       eslint: ^7.19.0
     dependencies:
       eslint: 7.32.0
-      eslint-config-standard: 16.0.3_bf1527f11d233ea3a2b6ea94c67e56a2
+      eslint-config-standard: 16.0.3_x4ksp4i5em7khivw5kkmm7swui
       eslint-plugin-import: 2.26.0_eslint@7.32.0
       eslint-plugin-mocha: 8.2.0_eslint@7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-promise: 4.3.1
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /@eslint/eslintrc/0.4.3:
@@ -338,12 +343,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -660,7 +675,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-standard/16.0.3_bf1527f11d233ea3a2b6ea94c67e56a2:
+  /eslint-config-standard/16.0.3_x4ksp4i5em7khivw5kkmm7swui:
     resolution: {integrity: sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==}
     peerDependencies:
       eslint: ^7.12.1
@@ -679,14 +694,33 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_ulu2225r2ychl26a37c6o2rfje:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-es/3.0.1_eslint@7.32.0:
@@ -704,7 +738,11 @@ packages:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
       array-includes: 3.1.4
       array.prototype.flat: 1.3.0
@@ -712,7 +750,7 @@ packages:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_ulu2225r2ychl26a37c6o2rfje
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -720,6 +758,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-mocha/8.2.0_eslint@7.32.0:
@@ -753,7 +795,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /eslint-plugin-svelte3/3.4.1_eslint@7.32.0+svelte@3.47.0:
+  /eslint-plugin-svelte3/3.4.1_4oxeyilw5mxcaksmcxtpjddhfe:
     resolution: {integrity: sha512-7p59WG8qV8L6wLdl4d/c3mdjkgVglQCdv5XOTk/iNPBKXuuV+Q0eFP5Wa6iJd/G2M1qR3BkLPEzaANOqKAZczw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -1630,7 +1672,7 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.5.9_svelte@3.47.0+typescript@4.6.3:
+  /svelte2tsx/0.5.9_ucc3fdkrl6lb7lhnlfimbouujy:
     resolution: {integrity: sha512-xTDASjlh+rKo4QRhTRYSH87sS7fRoyX67xhGIMPKa3FYqftRHRmMes6nVgEskiuhBovslNHYYpMMg5YM5n/STg==}
     peerDependencies:
       svelte: ^3.24

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -1,0 +1,40 @@
+<!-- Example of an icon component -->
+<!-- Icon: times-circle-line -->
+<!-- Source: iconify -->
+<!-- URL: https://icon-sets.iconify.design/clarity/times-circle-line/ -->
+
+<style>
+  .demo-icon {
+  	font-size: 1.25rem;
+  	line-height: 1.5rem;
+  	padding-right: 0.25rem;
+  }
+</style>
+
+<div class="demo-icon">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    aria-hidden="true"
+    role="img"
+    width="1em"
+    height="1em"
+    preserveAspectRatio="xMidYMid meet"
+    viewBox="0 0 36 36"
+  >
+    <path
+      fill="currentColor"
+      d="m19.61 18l4.86-4.86a1 1 0 0 0-1.41-1.41l-4.86 4.81l-4.89-4.89a1 1 0 0 0-1.41 1.41L16.78 18L12 22.72a1 1 0 1 0 1.41 1.41l4.77-4.77l4.74 4.74a1 1 0 0 0 1.41-1.41Z"
+      class="clr-i-outline clr-i-outline-path-1">
+    </path>
+    <path
+      fill="currentColor"
+      d="M18 34a16 16 0 1 1 16-16a16 16 0 0 1-16 16Zm0-30a14 14 0 1 0 14 14A14 14 0 0 0 18 4Z"
+      class="clr-i-outline clr-i-outline-path-2">
+    </path>
+    <path
+      fill="none"
+      d="M0 0h36v36H0z">
+    </path>
+  </svg>
+</div>

--- a/src/lib/Notifications.svelte
+++ b/src/lib/Notifications.svelte
@@ -227,7 +227,7 @@
     const persist = options.persist
     const computedTimeout = options.persist ? 0 : (options.timeout || timeout)
     const id = Math.random().toString(36).replace(/[^a-z]+/g, '')
-    const showProgress = options.showProgress ?? true // Default showProgress to true
+    const showProgress = options.showProgress ?? true
     const icon = options.icon // Should be a svelte component
 
     try {

--- a/src/lib/Notifications.svelte
+++ b/src/lib/Notifications.svelte
@@ -7,14 +7,25 @@
       </button>
       {/if}
       <div class="content">
+        {#if toast.icon}
+          <svelte:component this={toast.icon} />
+        {/if}
         {toast.message}
       </div>
-      <div 
-        class="progress" 
-        style="animation-duration: {toast.timeout}ms;"
-        on:animationend={() => maybePurge(toast) }>
-      </div>
-    </li>  
+      {#if toast.showProgress}
+        <div
+          class="progress"
+          style="animation-duration: {toast.timeout}ms;"
+          on:animationend={() => maybePurge(toast) }>
+        </div>
+      {:else}
+        {#await new Promise(resolve => setTimeout(resolve, toast.timeout))}
+          <span class="hidden">Toast Visable</span>
+        {:then}
+          <span class="hidden">Toast Timed Out { maybePurge(toast) }</span>
+        {/await}
+      {/if}
+    </li>
   {/each}
 </ul>
 
@@ -28,7 +39,7 @@
     margin: 0;
     z-index: 9999;
   }
-  
+
   .toasts > .toast {
     display: flex;
     align-items: center;
@@ -51,14 +62,14 @@
     border: 0;
     background-color: transparent;
   }
-  
+
   .toasts > .toast > .content {
     padding: 1vw;
     display: flex;
     font-weight: 500;
     margin-right: 20px;
   }
-  
+
   .toasts > .toast > .progress {
     position: absolute;
     bottom: 0;
@@ -69,7 +80,7 @@
     animation-timing-function: linear;
     animation-fill-mode: forwards;
   }
-  
+
   .toasts > .toast:before,
   .toasts > .toast:after {
     content:"";
@@ -81,7 +92,7 @@
     right:1vw;
     border-radius:100px / 10px;
   }
-  
+
   .toasts > .toast:after {
     right: 1vw;
     left: auto;
@@ -121,12 +132,12 @@
     }
   }
 
-  @keyframes shrink { 
-    0% { 
-      width: 98vw; 
+  @keyframes shrink {
+    0% {
+      width: 98vw;
     }
-    100% { 
-      width: 0; 
+    100% {
+      width: 0;
     }
   }
 
@@ -163,13 +174,13 @@
         transform: none;
       }
     }
-  
-    @keyframes shrink { 
-      0% { 
+
+    @keyframes shrink {
+      0% {
         width: 40vw;
       }
-      100% { 
-        width: 0; 
+      100% {
+        width: 0;
       }
     }
   }
@@ -183,6 +194,10 @@
     .toasts > .toast > .content {
       justify-content: flex-start;
     }
+  }
+
+  .hidden {
+    display: none;
   }
 </style>
 
@@ -216,6 +231,8 @@
     const persist = options.persist
     const computedTimeout = options.persist ? 0 : (options.timeout || timeout)
     const id = Math.random().toString(36).replace(/[^a-z]+/g, '')
+    const showProgress = options.showProgress ?? true // Default showProgress to true
+    const icon = options.icon // Should be a svelte component
 
     try {
       sessionStorage.setItem(
@@ -233,6 +250,8 @@
       background,
       persist,
       timeout: computedTimeout,
+      showProgress,
+      icon,
       width: '100%'
     }, ...toasts ]
   }

--- a/src/lib/Notifications.svelte
+++ b/src/lib/Notifications.svelte
@@ -228,7 +228,7 @@
     const computedTimeout = options.persist ? 0 : (options.timeout || timeout)
     const id = Math.random().toString(36).replace(/[^a-z]+/g, '')
     const showProgress = options.showProgress ?? true
-    const icon = options.icon // Should be a svelte component
+    const icon = options.icon
 
     try {
       sessionStorage.setItem(

--- a/src/lib/Notifications.svelte
+++ b/src/lib/Notifications.svelte
@@ -19,11 +19,7 @@
           on:animationend={() => maybePurge(toast) }>
         </div>
       {:else}
-        {#await new Promise(resolve => setTimeout(resolve, toast.timeout))}
-          <span class="hidden">Toast Visable</span>
-        {:then}
-          <span class="hidden">Toast Timed Out { maybePurge(toast) }</span>
-        {/await}
+        <span class="hidden">{maybePurgeAfterTimeout(toast)}</span>
       {/if}
     </li>
   {/each}
@@ -258,6 +254,10 @@
 
   function maybePurge (toast) {
     !toast.persist && purge(toast.id)
+  }
+
+  function maybePurgeAfterTimeout (toast) {
+    setTimeout(() => maybePurge(toast), toast.timeout)
   }
 
   function purge (id) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,16 +1,19 @@
 <script>
 	import { NotificationDisplay, notifier } from '$lib'
 
-const types = [ 'success', 'danger', 'warning', 'info', 'default' ]
-	
-let timeout = 3000
-let type = 'success'
-let text = 'This is the message which will display'
-let persist = false
+	import Icon from '$lib/Icon.svelte'
 
-function demo () {
-  notifier[type === 'default' ? 'send' : type](text, { timeout, persist })
-}
+	const types = [ 'success', 'danger', 'warning', 'info', 'default' ]
+
+	let timeout = 3000
+	let type = 'success'
+	let text = 'This is the message which will display'
+	let persist = false
+	let showProgress = true
+
+	function demo () {
+	  notifier[type === 'default' ? 'send' : type](text, { timeout, persist, showProgress, icon: Icon })
+	}
 </script>
 
 <NotificationDisplay />
@@ -29,7 +32,7 @@ function demo () {
       <option value={type}>{type}</option>
     {/each}
   </select>
-  
+
   <label class="form" for="timeou">
     Timeout {timeout}
   </label>
@@ -39,6 +42,13 @@ function demo () {
     <input type="checkbox" class="form" bind:checked={persist} id="persist" />
     <label for="persist" class="form">
       Persist
+    </label>
+  </div>
+
+	<div>
+    <input type="checkbox" class="form" bind:checked={showProgress} id="showProgress" />
+    <label for="showProgress" class="form">
+      Show Progress
     </label>
   </div>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -10,9 +10,10 @@
 	let text = 'This is the message which will display'
 	let persist = false
 	let showProgress = true
+	let showIcon = false
 
 	function demo () {
-	  notifier[type === 'default' ? 'send' : type](text, { timeout, persist, showProgress, icon: Icon })
+	  notifier[type === 'default' ? 'send' : type](text, { timeout, persist, showProgress, icon: showIcon ? Icon : null })
 	}
 </script>
 
@@ -49,6 +50,13 @@
     <input type="checkbox" class="form" bind:checked={showProgress} id="showProgress" />
     <label for="showProgress" class="form">
       Show Progress
+    </label>
+  </div>
+
+	<div>
+    <input type="checkbox" class="form" bind:checked={showIcon} id="showIcon" />
+    <label for="showIcon" class="form">
+      Show Icon
     </label>
   </div>
 


### PR DESCRIPTION
This PR aims to implement 2 additions:

- Add support for Icons in notifications, current implementation allows any svelte component.
> ![IconExample](https://user-images.githubusercontent.com/54558771/172025782-253f260a-a28b-4cf7-9d0d-c29d192afe79.png)
- Add a toggle for the progress bar to show or hide it. Mentioned in: #9.

All the changes were manually tested multiple times in order to assure that they won't break or conflict with existing features