### PR TITLE
[TypeScript] Change ITheme interface to accept other values.

### DIFF
--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -13,11 +13,11 @@ declare module "@beyonk/svelte-notifications" {
     }
 
     export interface ITheme {
-        danger: '#bb2124',
-        success: '#22bb33',
-        warning: '#f0ad4e',
-        info: '#5bc0de',
-        default: '#aaaaaa'
+        danger: string,
+        success: string,
+        warning: string,
+        info: string,
+        default: string
     }
     type IProps = { themes?: ITheme, timeout?: number, persist?: boolean }
 


### PR DESCRIPTION
Without it I cannot change default color values in typescript without error.

Error :
```
Type '{ danger: string; success: string; warning: string; info: string; default: string; }' is not assignable to type 'ITheme'.
  Types of property 'danger' are incompatible.
    Type 'string' is not assignable to type '"#bb2124"'
```